### PR TITLE
5.0.10: Bump version due to 5.0.3 release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>ome</groupId>
   <artifactId>pom-omero-client</artifactId>
   <packaging>pom</packaging>
-  <version>5.0.9</version>
+  <version>5.0.10</version>
 
   <name>pom-omero-client</name>
   <url>http://github.com/ome/pom-omero-client</url>
@@ -50,8 +50,8 @@
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <omero.version>5.0.2-${ice.version}-b26</omero.version>
-      <bioformats.version>5.0.2</bioformats.version>
+      <omero.version>5.0.3-${ice.version}-b41</omero.version>
+      <bioformats.version>5.0.3</bioformats.version>
   </properties>
 
   <dependencyManagement>
@@ -104,8 +104,8 @@
     <profile>
       <id>dev</id>
         <properties>
-          <omero.version>5.0.3-${ice.version}-SNAPSHOT</omero.version>
-          <bioformats.version>5.0.3-SNAPSHOT</bioformats.version>
+          <omero.version>5.0.4-${ice.version}-SNAPSHOT</omero.version>
+          <bioformats.version>5.0.4-SNAPSHOT</bioformats.version>
         </properties>
     </profile>
     <profile>


### PR DESCRIPTION
This PR updates the version numbers in the POM file due to 5.0.3 release. I think we need to also produce a 5.0.4-SNAPSHOT and upload it to artifactory for the `dev` profile to work (?).
