### PR TITLE
5.0.11: Bump version due to 5.0.4 release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>ome</groupId>
   <artifactId>pom-omero-client</artifactId>
   <packaging>pom</packaging>
-  <version>5.0.10</version>
+  <version>5.0.11</version>
 
   <name>pom-omero-client</name>
   <url>http://github.com/ome/pom-omero-client</url>
@@ -50,8 +50,8 @@
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <omero.version>5.0.3-${ice.version}-b41</omero.version>
-      <bioformats.version>5.0.3</bioformats.version>
+      <omero.version>5.0.4-${ice.version}-b41</omero.version>
+      <bioformats.version>5.0.4</bioformats.version>
   </properties>
 
   <dependencyManagement>
@@ -104,8 +104,8 @@
     <profile>
       <id>dev</id>
         <properties>
-          <omero.version>5.0.4-${ice.version}-SNAPSHOT</omero.version>
-          <bioformats.version>5.0.4-SNAPSHOT</bioformats.version>
+          <omero.version>5.0.5-${ice.version}-SNAPSHOT</omero.version>
+          <bioformats.version>5.0.5-SNAPSHOT</bioformats.version>
         </properties>
     </profile>
     <profile>


### PR DESCRIPTION
This PR updates the Maven build file with the respective version numbers post-5.0.4 release.
For Travis failures, see the discussion on https://github.com/ome/pom-omero-client/pull/1.
