### PR TITLE
pom-omero-client 5.2.2: bump Bio-Formats version to 5.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>ome</groupId>
   <artifactId>pom-omero-client</artifactId>
   <packaging>pom</packaging>
-  <version>5.2.1</version>
+  <version>5.2.2</version>
 
   <name>pom-omero-client</name>
   <url>http://github.com/ome/pom-omero-client</url>
@@ -51,7 +51,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <omero.version>5.2.0-${ice.version}</omero.version>
-      <bioformats.version>5.1.6</bioformats.version>
+      <bioformats.version>5.1.7</bioformats.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Following the release of Bio-Formats 5.1.7, this bumps the shipped version of Bio-Formats in the pom-omero-client.