### PR TITLE
Remove secure environment variables from Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,5 @@ branches:
     - dev_5_0
     - dev_5_1
     - dev_5_2
-env:
-  global:
-    - secure: "FhQxNU0O4aylgoJDK6ymEjYc3ILFl4IjjrPx7OdCeG+UMqBc9da/0CM/l6ehWHHxn0VQUc0+7qZgQjguRdMRGVApMIxY2a9vipYnG6DwYKQD59oqoJHfTAqtb+50vdC85pyNiBIetraOdyfJfjVTmAgXRTUwW5GdgSklJFsqjIY="
-    - secure: "PYwpkDwhGfQgIF9axubaKo6zuDxl+PF3zKc86SRxnGTk7bNYd5NFMBP1IAq4oBe0TgujC6fc4lH3Od6FpIy3PcFuRHpQaSwg8r5ZvyvNqGVlglyOitLKoLnByXDUkmATPKyMZDnVvPepGLs/6lsw9yjlO881Wy00JWYGHP2iWM8="
 
 after_success: if [[ "${TRAVIS_PULL_REQUEST}" = "false" ]]; then mvn -U -B -e clean deploy -DskipTests; fi

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>ome</groupId>
   <artifactId>pom-omero-client</artifactId>
   <packaging>pom</packaging>
-  <version>5.2.11</version>
+  <version>5.2.12-SNAPSHOT</version>
 
   <name>pom-omero-client</name>
   <url>http://github.com/ome/pom-omero-client</url>


### PR DESCRIPTION
This PR reviews the usage of environment variables allowing to push artifacts to artifactory to use the [Repository settings](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings) options.

The goal of this change is to simplify the management of these credentials especially when shared across multiple development branches.