### PR TITLE
Add distributionManagement section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,19 @@
     </repository>
   </repositories>
 
+  <distributionManagement>
+    <repository>
+      <id>ome.staging</id>
+      <name>OME Staging Repository</name>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
+    </repository>
+    <snapshotRepository>
+      <id>ome.snapshots</id>
+      <name>OME Snapshots Repository</name>
+      <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <pluginRepositories>
       <pluginRepository>
           <id>evgenyg.artifactoryonline.com</id>

--- a/pom.xml
+++ b/pom.xml
@@ -149,12 +149,12 @@
     <repository>
       <id>ome.staging</id>
       <name>OME Staging Repository</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
     </repository>
     <snapshotRepository>
       <id>ome.snapshots</id>
       <name>OME Snapshots Repository</name>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
+      <url>https://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
With Maven 3.5.0, although we are using a dedicated plugin for deploying to
the Artifactory, a distributionManagement element seems required for the deploy
phase.

Tested locally by running the following with Maven 3.5.0:

```
mvn clean install -Dmaven.repo.local=/tmp/.m2/repository
mvn clean deploy -Dmaven.repo.local=/tmp/.m2/repository -DskipTests=true
```

Without this PR, the second command fails with `Deployment failed: repository element was not specified in the POM inside distributionManagement element or in -DaltDeploymentRepository=id::layout::url parameter`. With this PR the deployment command fails with authentication issues when deploying to the `ome.staging` repository (this should not happy under Travis with the encrypted credentials).