### PR TITLE
Bump the Maven Artifactory plugin to 2.6.1 and use HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,26 +145,15 @@
     </repository>
   </repositories>
 
-  <distributionManagement>
-    <repository>
-      <id>ome.staging</id>
-      <name>OME Staging Repository</name>
-      <url>https://artifacts.openmicroscopy.org/artifactory/ome.staging</url>
-    </repository>
-    <snapshotRepository>
-      <id>ome.snapshots</id>
-      <name>OME Snapshots Repository</name>
-      <url>https://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-
   <pluginRepositories>
-      <pluginRepository>
-          <id>evgenyg.artifactoryonline.com</id>
-          <url>http://evgenyg.artifactoryonline.com/evgenyg/repo</url>
-          <snapshots><enabled>true</enabled></snapshots>
-          <releases><enabled>true</enabled></releases>
-      </pluginRepository>
+    <pluginRepository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>bintray-plugins</name>
+      <url>http://jcenter.bintray.com</url>
+    </pluginRepository>
   </pluginRepositories>
 
   <build>
@@ -172,7 +161,7 @@
       <plugin>
           <groupId>org.jfrog.buildinfo</groupId>
           <artifactId>artifactory-maven-plugin</artifactId>
-          <version>2.2.1</version>
+          <version>2.6.1</version>
           <inherited>false</inherited>
           <executions>
               <execution>
@@ -190,7 +179,7 @@
                           <propertiesFile>publish.properties</propertiesFile>
                       </artifactory>
                       <publisher>
-                          <contextUrl>http://artifacts.openmicroscopy.org/artifactory/</contextUrl>
+                          <contextUrl>https://artifacts.openmicroscopy.org/artifactory/</contextUrl>
                           <username>${env.CI_DEPLOY_USER}</username>
                           <password>${env.CI_DEPLOY_PASS}</password>
                           <repoKey>ome.staging</repoKey>


### PR DESCRIPTION
Also remove the `distributionManagement` section as it looks unnecessary for the deployment

Tested locally (Apache Maven 3.5.0) by running `mvn clean deploy` after changing `pom.xml` to to use `ome.experimental` as the `repoKey` and `username` and `password` to use a valid user allowed to depoy to this repository.